### PR TITLE
Fix possible typo/bug when accessing block's header's timestamp.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+ccan/config.h

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.o
 ccan/config.h
+bitcoin-iterate
+ccan/tools/configurator/configurator

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 ccan/config.h
 bitcoin-iterate
 ccan/tools/configurator/configurator
+ccan/tools/configurator/configurator.dSYM/*
+configurator.out.dSYM/*

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ CFLAGS = -O3 -flto -ggdb -I $(CCANDIR) -Wall
 LDFLAGS = -O3 -flto
 #CFLAGS = -ggdb -I $(CCANDIR) -Wall
 LDLIBS := -lcrypto
+BIN_DIR := /usr/local/bin
+
+install: all
+	cp bitcoin-iterate $(BIN_DIR)/bitcoin-iterate
 
 all: bitcoin-iterate doc/bitcoin-iterate.1
 

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,12 @@ LDFLAGS = -O3 -flto
 LDLIBS := -lcrypto
 BIN_DIR := /usr/local/bin
 
-install: all
-	cp bitcoin-iterate $(BIN_DIR)/bitcoin-iterate
-
 all: bitcoin-iterate doc/bitcoin-iterate.1
+
+.PHONY: install
+
+install:
+	cp bitcoin-iterate $(BIN_DIR)/bitcoin-iterate
 
 $(CCAN_OBJS) $(ITERATE_OBJS): ccan/config.h
 

--- a/iterate.c
+++ b/iterate.c
@@ -171,7 +171,7 @@ static void add_utxo(const tal_t *tal_ctx,
 	utxo->num_outputs = t->output_count;
 	utxo->unspent_outputs = spend_count;
 	utxo->height = b->height;
-	utxo->timestamp = b->b->timestamp;
+	utxo->timestamp = b->bh.timestamp;
 	for (i = 0; i < utxo->num_outputs; i++)
 		utxo->amount[i] = t->output[i].amount;
 	guess_output_types(t, output_types(utxo));
@@ -458,7 +458,7 @@ static void print_format(const char *format,
 				break;
 			case 'D':
 				printf("%"PRIi64,
-				       calculate_bdd(utxo_map, t, txnum == 0, b->b->timestamp));
+				       calculate_bdd(utxo_map, t, txnum == 0, b->bh.timestamp));
 				break;
 			case 'X':
 				dump_tx(t);


### PR DESCRIPTION
Just came across bitcoin-iterate; great project!

Cloned the source and attempted to `make` but hit an error:

```
$ make
cc -O3 -flto -ggdb -I ccan/ -Wall  -O3 -flto  ccan/tools/configurator/configurator.c  -lcrypto -o ccan/tools/configurator/configurator
ccan/tools/configurator/configurator > ccan/config.h
cc -O3 -flto -ggdb -I ccan/ -Wall   -c -o iterate.o iterate.c
iterate.c: In function ‘add_utxo’:
iterate.c:174:21: error: ‘const struct block’ has no member named ‘b’
  utxo->timestamp = b->b->timestamp;
                     ^
iterate.c: In function ‘print_format’:
iterate.c:461:52: error: ‘struct block’ has no member named ‘b’
            calculate_bdd(utxo_map, t, txnum == 0, b->b->timestamp));
                                                    ^
make: *** [iterate.o] Error 1
```
I am not a C-programmer, but I poked around and realized that it might just be due to a typo (should have been `b->bh.timestamp` instead of `b->b->timestamp`).

Looks like this was introduced in [this commit](https://github.com/rustyrussell/bitcoin-iterate/commit/51797979f1f15f0440b00e3c5a3005cdfea08472).