### PR TITLE
Dabbing some ointment on the first cut of segwit support.

### DIFF
--- a/iterate.c
+++ b/iterate.c
@@ -485,6 +485,15 @@ static void print_format(const char *format,
 			case 'l':
 				printf("%u", t->len);
 				break;
+			case 'L':
+				printf("%u", t->swlen);
+				break;
+			case 'W':
+				printf("%u", t->swlen + 3*t->len);
+				break;
+			case 'V':
+				printf("%u", (t->swlen + 3*t->len + 3) / 4);
+				break;
 			case 'N':
 				printf("%zu", txnum);
 				break;

--- a/types.h
+++ b/types.h
@@ -30,6 +30,7 @@ struct bitcoin_transaction {
 	/* We calculate these as we read in transaction: */
 	u8 sha256[SHA256_DIGEST_LENGTH];
 	u32 len;
+	u32 swlen;
 };
 
 struct bitcoin_transaction_output {


### PR DESCRIPTION
Bugfix: you need to update input_count after reading the "0" marker for transactions with witness data. Seems to be enough to get it working on both testnet and mainnet data.

Addition: track the length of the transaction including witness data.

Outputs: %tL -- raw tx length including witness data, (%tl remains the length without witness data), %tW gives the weight, %tV gives the vsize (weight/4 rounded up).

Edit: (probably better to make %tl be the vsize, and introduce a different option for the length without witness data)