### PR TITLE
Add Lightning functionality: Add scid -> amount_sat, time lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/blocks/*
 *.o
 ccan/config.h
 bitcoin-iterate

--- a/iterate.c
+++ b/iterate.c
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <errno.h>
+#include <ctype.h>
 #include "parse.h"
 #include "blockfiles.h"
 #include "io.h"
@@ -651,6 +652,120 @@ static char *opt_set_hash(const char *arg, u8 *h)
 	return NULL;
 }
 
+static bool is_all_digits(const char *p, size_t len)
+{
+	while (len--) {
+		if (!isdigit((unsigned char)*p++))
+			return false;
+	}
+	return true;
+}
+
+static bool validate_scid_line(const char *line, size_t len)
+{
+	/* Trim leading/trailing whitespace */
+	const char *start = line;
+	const char *end = line + len;
+	while (start < end && (*start == ' ' || *start == '\t' || *start == '\r'))
+		start++;
+	while (end > start && (end[-1] == ' ' || end[-1] == '\t' || end[-1] == '\r'))
+		end--;
+	if (start == end)
+		return true; /* allow empty lines */
+
+	/* Format: digits 'x' digits 'x' digits */
+	const char *p = start;
+	const char *x1 = memchr(p, 'x', end - p);
+	if (!x1 || x1 == p)
+		return false;
+	if (!is_all_digits(p, (size_t)(x1 - p)))
+		return false;
+	p = x1 + 1;
+	const char *x2 = memchr(p, 'x', end - p);
+	if (!x2 || x2 == p)
+		return false;
+	if (!is_all_digits(p, (size_t)(x2 - p)))
+		return false;
+	p = x2 + 1;
+	if (p >= end)
+		return false;
+	if (!is_all_digits(p, (size_t)(end - p)))
+		return false;
+	return true;
+}
+
+struct scid_req {
+	unsigned long height;
+	unsigned long txidx;
+	unsigned long outidx;
+	unsigned long original_index;
+	char *text;
+	bool found;
+	u64 amount_sat;
+};
+
+static int cmp_scid_hto(const void *ap, const void *bp)
+{
+	const struct scid_req *a = ap, *b = bp;
+	if (a->height != b->height)
+		return (a->height < b->height) ? -1 : 1;
+	if (a->txidx != b->txidx)
+		return (a->txidx < b->txidx) ? -1 : 1;
+	if (a->outidx != b->outidx)
+		return (a->outidx < b->outidx) ? -1 : 1;
+	return 0;
+}
+
+static int cmp_scid_original_index(const void *ap, const void *bp)
+{
+	const struct scid_req *a = ap, *b = bp;
+	if (a->original_index == b->original_index)
+		return 0;
+	return (a->original_index < b->original_index) ? -1 : 1;
+}
+
+static bool parse_scid_triplet(const char *line, size_t len,
+				   unsigned long *h,
+                                   unsigned long *t,
+                                   unsigned long *o,
+                                   char **text_out,
+                                   const tal_t *tal_ctx)
+{
+	const char *start = line;
+	const char *end = line + len;
+	while (start < end && (*start == ' ' || *start == '\t' || *start == '\r'))
+		start++;
+	while (end > start && (end[-1] == ' ' || end[-1] == '\t' || end[-1] == '\r'))
+		end--;
+	if (start == end) {
+		*text_out = tal_strdup(tal_ctx, "");
+		return true; /* Empty line allowed */
+	}
+	const char *x1 = memchr(start, 'x', (size_t)(end - start));
+	if (!x1)
+		return false;
+	const char *x2 = memchr(x1 + 1, 'x', (size_t)(end - (x1 + 1)));
+	if (!x2)
+		return false;
+	char *tmp;
+	unsigned long hh, tt, oo;
+	errno = 0;
+	hh = strtoul(start, &tmp, 10);
+	if (errno != 0 || tmp != x1)
+		return false;
+	errno = 0;
+	tt = strtoul(x1 + 1, &tmp, 10);
+	if (errno != 0 || tmp != x2)
+		return false;
+	errno = 0;
+	oo = strtoul(x2 + 1, &tmp, 10);
+	if (errno != 0 || tmp != end)
+		return false;
+	*h = hh; *t = tt; *o = oo;
+	*text_out = tal_strndup(tal_ctx, start, (size_t)(end - start));
+	return true;
+}
+
 static bool read_utxo_cache(const tal_t *ctx,
 			    struct utxo_map *utxo_map,
 			    const char *cachedir,
@@ -842,6 +957,11 @@ int main(int argc, char *argv[])
 		start_hash[SHA256_DIGEST_LENGTH] = { 0 };
 	unsigned int utxo_period = 144;
 	enum networks network = MAIN;
+	char *scid_file = NULL;
+	char *scid_out = NULL;
+	struct scid_req *scids = NULL;
+	size_t num_scids = 0;
+	size_t scid_pos = 0;
 
 	err_set_progname(argv[0]);
 	opt_register_noarg("-h|--help", opt_usage_and_exit,
@@ -939,10 +1059,73 @@ int main(int argc, char *argv[])
 			 "Block number to end at instead of longest chain.");
 	opt_register_arg("--cache", opt_set_charp, NULL, &cachedir,
 			 "Cache for multiple runs.");
+    opt_register_arg("--scid-file", opt_set_charp, NULL, &scid_file,
+                     "Path to file with SCIDs (one per line): <block-height>x<transaction-idx>x<output-idx>");
+    opt_register_arg("--scid-out", opt_set_charp, NULL, &scid_out,
+                     "Path to write SCID amounts (two columns)");
 	opt_parse(&argc, argv, opt_log_stderr_exit);
 
 	if (argc != 1)
 		opt_usage_and_exit(NULL);
+
+    if (scid_file) {
+        char *contents = grab_file(tal_ctx, scid_file);
+        if (!contents)
+            err(1, "Could not read %s", scid_file);
+        size_t len = tal_count(contents) - 1; /* includes trailing NUL */
+        const char *p = contents;
+        const char *end = contents + len;
+        unsigned long line_no = 1;
+        /* First pass: count non-empty valid lines */
+        while (p < end) {
+            const char *nl = memchr(p, '\n', (size_t)(end - p));
+            const char *line_end = nl ? nl : end;
+            if (!validate_scid_line(p, (size_t)(line_end - p)))
+                errx(1, "Invalid SCID format on line %lu", line_no);
+            /* check if not empty after trim */
+            const char *s = p, *e = line_end;
+            while (s < e && (*s == ' ' || *s == '\t' || *s == '\r')) s++;
+            while (e > s && (e[-1] == ' ' || e[-1] == '\t' || e[-1] == '\r')) e--;
+            if (s < e)
+                num_scids++;
+            line_no++;
+            if (!nl)
+                break;
+            p = nl + 1;
+        }
+        scids = tal_arr(tal_ctx, struct scid_req, num_scids);
+        for (size_t ii = 0; ii < num_scids; ii++) {
+            scids[ii].found = false;
+            scids[ii].amount_sat = 0;
+            scids[ii].text = NULL;
+            scids[ii].original_index = ii;
+        }
+        p = contents;
+        end = contents + len;
+        line_no = 1;
+        size_t idx = 0;
+        while (p < end) {
+            const char *nl = memchr(p, '\n', (size_t)(end - p));
+            const char *line_end = nl ? nl : end;
+            unsigned long h, t, o;
+            char *text;
+            if (!parse_scid_triplet(p, (size_t)(line_end - p), &h, &t, &o, &text, tal_ctx))
+                errx(1, "Invalid SCID format on line %lu", line_no);
+            if (text && *text) {
+                scids[idx].height = h;
+                scids[idx].txidx = t;
+                scids[idx].outidx = o;
+                scids[idx].text = text;
+                idx++;
+            }
+            line_no++;
+            if (!nl)
+                break;
+            p = nl + 1;
+        }
+        /* Sort by height/txidx/outidx */
+        qsort(scids, num_scids, sizeof(scids[0]), cmp_scid_hto);
+    }
 
 	if (use_testnet) {
 		netmarker = 0x0709110B;
@@ -1187,8 +1370,8 @@ check_genesis:
 		    == (best->height / progress_marks) - 1)
 			fprintf(stderr, ".");
 
-		/* Don't read transactions if we don't have to */
-		if (!txfmt && !inputfmt && !outputfmt && !utxofmt)
+		/* Don't read transactions if we don't have to, unless SCIDs need matching */
+		if (!txfmt && !inputfmt && !outputfmt && !utxofmt && num_scids == 0)
 			continue;
 
 		/* If we haven't started and don't need to gather UTXO, skip */
@@ -1227,6 +1410,17 @@ check_genesis:
 				}
 			}
 
+			/* SCID matching: we assume scids sorted by height,txidx,outidx */
+			while (scid_pos < num_scids && scids[scid_pos].height == (unsigned long)b->height && scids[scid_pos].txidx == (unsigned long)i) {
+				unsigned long target_out = scids[scid_pos].outidx;
+				if (target_out < tx[i].output_count) {
+					scids[scid_pos].amount_sat = tx[i].output[target_out].amount;
+					scids[scid_pos].found = true;
+				}
+				/* move to next scid with same h/tx or beyond */
+				scid_pos++;
+			}
+
 			if (needs_fee) {
 				/* Now we can release consumed utxos;
 				 * before there was a possibility of %tF */
@@ -1250,6 +1444,27 @@ check_genesis:
 		    print_format(utxofmt, &utxo_map, b, NULL, 0, NULL, NULL, utxo);
 		  }
 		}
+	}
+
+	/* If requested, write SCID results */
+	if (num_scids > 0) {
+		FILE *outf = stdout;
+		if (scid_out) {
+			outf = fopen(scid_out, "w");
+			if (!outf)
+				err(1, "Could not open %s for writing", scid_out);
+		}
+		/* Preserve input order: stable output by original listing */
+		struct scid_req *copy = tal_dup_arr(tal_ctx, struct scid_req, scids, num_scids, 0);
+		qsort(copy, num_scids, sizeof(copy[0]), cmp_scid_original_index);
+		for (size_t k = 0; k < num_scids; k++) {
+			if (copy[k].text && *copy[k].text) {
+				/* two columns: scid_text amount */
+				fprintf(outf, "%s\t%" PRIu64 "\n", copy[k].text, copy[k].found ? copy[k].amount_sat : 0);
+			}
+		}
+		if (outf != stdout)
+			fclose(outf);
 	}
 	return 0;
 }

--- a/iterate.c
+++ b/iterate.c
@@ -694,36 +694,6 @@ static bool validate_scid_line(const char *line, size_t len)
 	return true;
 }
 
-struct scid_req {
-	unsigned long height;
-	unsigned long txidx;
-	unsigned long outidx;
-	unsigned long original_index;
-	char *text;
-	bool found;
-	u64 amount_sat;
-};
-
-static int cmp_scid_hto(const void *ap, const void *bp)
-{
-	const struct scid_req *a = ap, *b = bp;
-	if (a->height != b->height)
-		return (a->height < b->height) ? -1 : 1;
-	if (a->txidx != b->txidx)
-		return (a->txidx < b->txidx) ? -1 : 1;
-	if (a->outidx != b->outidx)
-		return (a->outidx < b->outidx) ? -1 : 1;
-	return 0;
-}
-
-static int cmp_scid_original_index(const void *ap, const void *bp)
-{
-	const struct scid_req *a = ap, *b = bp;
-	if (a->original_index == b->original_index)
-		return 0;
-	return (a->original_index < b->original_index) ? -1 : 1;
-}
-
 static bool parse_scid_triplet(const char *line, size_t len,
 				   unsigned long *h,
                                    unsigned long *t,
@@ -764,6 +734,27 @@ static bool parse_scid_triplet(const char *line, size_t len,
 	*h = hh; *t = tt; *o = oo;
 	*text_out = tal_strndup(tal_ctx, start, (size_t)(end - start));
 	return true;
+}
+
+static bool read_next_scid_fp(FILE *fp, const tal_t *tal_ctx,
+                              unsigned long *h,
+                              unsigned long *t,
+                              unsigned long *o,
+                              char **text_out)
+{
+	char *line = NULL;
+	size_t n = 0;
+	ssize_t r;
+	while ((r = getline(&line, &n, fp)) != -1) {
+		if (!validate_scid_line(line, (size_t)r))
+			continue;
+		if (parse_scid_triplet(line, (size_t)r, h, t, o, text_out, tal_ctx)) {
+			free(line);
+			return (*text_out && **text_out);
+		}
+	}
+	free(line);
+	return false;
 }
 
 static bool read_utxo_cache(const tal_t *ctx,
@@ -851,10 +842,10 @@ static bool add_block(struct block_map *block_map, struct block *b,
 	struct block *prev, *old = block_map_get(block_map, b->sha);
 
 	if (old) {
-		warnx("Already have "SHA_FMT" from %s %lu/%u",
+	warnx("Already have "SHA_FMT" from %s %lld/%u",
 		      SHA_VALS(b->sha),
 		      block_fnames[old->filenum],
-		      old->pos, old->bh.len);
+	      (long long)old->pos, old->bh.len);
 		block_map_delkey(block_map, b->sha);
 	}
 	block_map_add(block_map, b);
@@ -959,9 +950,10 @@ int main(int argc, char *argv[])
 	enum networks network = MAIN;
 	char *scid_file = NULL;
 	char *scid_out = NULL;
-	struct scid_req *scids = NULL;
-	size_t num_scids = 0;
-	size_t scid_pos = 0;
+	FILE *scid_fp = NULL;
+	unsigned long cur_h = 0, cur_t = 0, cur_o = 0;
+	char *cur_scid_text = NULL;
+	bool have_scid = false;
 
 	err_set_progname(argv[0]);
 	opt_register_noarg("-h|--help", opt_usage_and_exit,
@@ -1060,7 +1052,7 @@ int main(int argc, char *argv[])
 	opt_register_arg("--cache", opt_set_charp, NULL, &cachedir,
 			 "Cache for multiple runs.");
     opt_register_arg("--scid-file", opt_set_charp, NULL, &scid_file,
-                     "Path to file with SCIDs (one per line): <block-height>x<transaction-idx>x<output-idx>");
+                     "Path to file with SCIDs (sorted): <block-height>x<transaction-idx>x<output-idx>");
     opt_register_arg("--scid-out", opt_set_charp, NULL, &scid_out,
                      "Path to write SCID amounts (two columns)");
 	opt_parse(&argc, argv, opt_log_stderr_exit);
@@ -1069,62 +1061,10 @@ int main(int argc, char *argv[])
 		opt_usage_and_exit(NULL);
 
     if (scid_file) {
-        char *contents = grab_file(tal_ctx, scid_file);
-        if (!contents)
-            err(1, "Could not read %s", scid_file);
-        size_t len = tal_count(contents) - 1; /* includes trailing NUL */
-        const char *p = contents;
-        const char *end = contents + len;
-        unsigned long line_no = 1;
-        /* First pass: count non-empty valid lines */
-        while (p < end) {
-            const char *nl = memchr(p, '\n', (size_t)(end - p));
-            const char *line_end = nl ? nl : end;
-            if (!validate_scid_line(p, (size_t)(line_end - p)))
-                errx(1, "Invalid SCID format on line %lu", line_no);
-            /* check if not empty after trim */
-            const char *s = p, *e = line_end;
-            while (s < e && (*s == ' ' || *s == '\t' || *s == '\r')) s++;
-            while (e > s && (e[-1] == ' ' || e[-1] == '\t' || e[-1] == '\r')) e--;
-            if (s < e)
-                num_scids++;
-            line_no++;
-            if (!nl)
-                break;
-            p = nl + 1;
-        }
-        scids = tal_arr(tal_ctx, struct scid_req, num_scids);
-        for (size_t ii = 0; ii < num_scids; ii++) {
-            scids[ii].found = false;
-            scids[ii].amount_sat = 0;
-            scids[ii].text = NULL;
-            scids[ii].original_index = ii;
-        }
-        p = contents;
-        end = contents + len;
-        line_no = 1;
-        size_t idx = 0;
-        while (p < end) {
-            const char *nl = memchr(p, '\n', (size_t)(end - p));
-            const char *line_end = nl ? nl : end;
-            unsigned long h, t, o;
-            char *text;
-            if (!parse_scid_triplet(p, (size_t)(line_end - p), &h, &t, &o, &text, tal_ctx))
-                errx(1, "Invalid SCID format on line %lu", line_no);
-            if (text && *text) {
-                scids[idx].height = h;
-                scids[idx].txidx = t;
-                scids[idx].outidx = o;
-                scids[idx].text = text;
-                idx++;
-            }
-            line_no++;
-            if (!nl)
-                break;
-            p = nl + 1;
-        }
-        /* Sort by height/txidx/outidx */
-        qsort(scids, num_scids, sizeof(scids[0]), cmp_scid_hto);
+        scid_fp = fopen(scid_file, "r");
+        if (!scid_fp)
+            err(1, "Could not open %s", scid_file);
+        have_scid = read_next_scid_fp(scid_fp, tal_ctx, &cur_h, &cur_t, &cur_o, &cur_scid_text);
     }
 
 	if (use_testnet) {
@@ -1191,13 +1131,13 @@ int main(int argc, char *argv[])
 			block_start = off;
 			if (!next_block_header_prefix(f, &off, netmarker)) {
 				if (off != block_start)
-					warnx("Skipped %lu at end of %s",
-					      off - block_start, block_fnames[i]);
+					warnx("Skipped %lld at end of %s",
+					      (long long)(off - block_start), block_fnames[i]);
 				break;
 			}
 			if (off != block_start)
-				warnx("Skipped %lu@%lu in %s",
-				      off - block_start, block_start,
+				warnx("Skipped %lld@%lld in %s",
+				      (long long)(off - block_start), (long long)block_start,
 				      block_fnames[i]);
 
 			block_start = off;
@@ -1341,6 +1281,14 @@ check_genesis:
 			fprintf(stderr, "Did not find valid UTXO cache\n");
 	}
 
+	/* Prepare output stream for SCIDs */
+	FILE *scid_outf = NULL;
+	if (scid_file) {
+		scid_outf = scid_out ? fopen(scid_out, "w") : stdout;
+		if (!scid_outf)
+			err(1, "Could not open %s for writing", scid_out);
+	}
+
 	/* Now run forwards. */
 	for (b = genesis; b; b = b->next) {
 		off_t off;
@@ -1371,7 +1319,7 @@ check_genesis:
 			fprintf(stderr, ".");
 
 		/* Don't read transactions if we don't have to, unless SCIDs need matching */
-		if (!txfmt && !inputfmt && !outputfmt && !utxofmt && num_scids == 0)
+		if (!txfmt && !inputfmt && !outputfmt && !utxofmt && !have_scid)
 			continue;
 
 		/* If we haven't started and don't need to gather UTXO, skip */
@@ -1410,15 +1358,25 @@ check_genesis:
 				}
 			}
 
-			/* SCID matching: we assume scids sorted by height,txidx,outidx */
-			while (scid_pos < num_scids && scids[scid_pos].height == (unsigned long)b->height && scids[scid_pos].txidx == (unsigned long)i) {
-				unsigned long target_out = scids[scid_pos].outidx;
-				if (target_out < tx[i].output_count) {
-					scids[scid_pos].amount_sat = tx[i].output[target_out].amount;
-					scids[scid_pos].found = true;
+			/* SCID matching: streaming from sorted file */
+			while (have_scid && (long)cur_h < b->height) {
+				/* cannot match in past blocks; advance to next scid */
+				have_scid = read_next_scid_fp(scid_fp, tal_ctx, &cur_h, &cur_t, &cur_o, &cur_scid_text);
+			}
+			if (have_scid && (unsigned long)b->height == cur_h) {
+				/* Consume all SCIDs for this block and current/next txs */
+				while (have_scid && (unsigned long)b->height == cur_h && (unsigned long)i == cur_t) {
+					unsigned long target_out = cur_o;
+					u64 amt = 0;
+					if (target_out < tx[i].output_count)
+						amt = tx[i].output[target_out].amount;
+					if (scid_outf && cur_scid_text && *cur_scid_text) {
+						fprintf(scid_outf, "%s:%u:%" PRIu64 "\n", cur_scid_text, b->bh.timestamp, amt);
+						if (!quiet && scid_outf != stdout)
+							fprintf(stdout, "%s:%u:%" PRIu64 "\n", cur_scid_text, b->bh.timestamp, amt);
+					}
+					have_scid = read_next_scid_fp(scid_fp, tal_ctx, &cur_h, &cur_t, &cur_o, &cur_scid_text);
 				}
-				/* move to next scid with same h/tx or beyond */
-				scid_pos++;
 			}
 
 			if (needs_fee) {
@@ -1446,25 +1404,9 @@ check_genesis:
 		}
 	}
 
-	/* If requested, write SCID results */
-	if (num_scids > 0) {
-		FILE *outf = stdout;
-		if (scid_out) {
-			outf = fopen(scid_out, "w");
-			if (!outf)
-				err(1, "Could not open %s for writing", scid_out);
-		}
-		/* Preserve input order: stable output by original listing */
-		struct scid_req *copy = tal_dup_arr(tal_ctx, struct scid_req, scids, num_scids, 0);
-		qsort(copy, num_scids, sizeof(copy[0]), cmp_scid_original_index);
-		for (size_t k = 0; k < num_scids; k++) {
-			if (copy[k].text && *copy[k].text) {
-				/* two columns: scid_text amount */
-				fprintf(outf, "%s\t%" PRIu64 "\n", copy[k].text, copy[k].found ? copy[k].amount_sat : 0);
-			}
-		}
-		if (outf != stdout)
-			fclose(outf);
-	}
+	if (scid_outf && scid_outf != stdout)
+		fclose(scid_outf);
+
+	/* No post-loop SCID write: we stream results during iteration */
 	return 0;
 }

--- a/iterate.c
+++ b/iterate.c
@@ -663,15 +663,18 @@ static bool is_all_digits(const char *p, size_t len)
 
 static bool validate_scid_line(const char *line, size_t len)
 {
-	/* Trim leading/trailing whitespace */
 	const char *start = line;
 	const char *end = line + len;
-	while (start < end && (*start == ' ' || *start == '\t' || *start == '\r'))
+	
+	/* Trim whitespace */
+	while (start < end && isspace((unsigned char)*start))
 		start++;
-	while (end > start && (end[-1] == ' ' || end[-1] == '\t' || end[-1] == '\r'))
+	while (end > start && isspace((unsigned char)end[-1]))
 		end--;
+	
+	/* Allow empty lines */
 	if (start == end)
-		return true; /* allow empty lines */
+		return true;
 
 	/* Format: digits 'x' digits 'x' digits */
 	const char *p = start;
@@ -680,79 +683,101 @@ static bool validate_scid_line(const char *line, size_t len)
 		return false;
 	if (!is_all_digits(p, (size_t)(x1 - p)))
 		return false;
+	
 	p = x1 + 1;
 	const char *x2 = memchr(p, 'x', end - p);
 	if (!x2 || x2 == p)
 		return false;
 	if (!is_all_digits(p, (size_t)(x2 - p)))
 		return false;
+	
 	p = x2 + 1;
 	if (p >= end)
 		return false;
 	if (!is_all_digits(p, (size_t)(end - p)))
 		return false;
+	
 	return true;
 }
 
 static bool parse_scid_triplet(const char *line, size_t len,
-				   unsigned long *h,
-                                   unsigned long *t,
-                                   unsigned long *o,
-                                   char **text_out,
-                                   const tal_t *tal_ctx)
+	unsigned long *h,
+	unsigned long *t,
+	unsigned long *o,
+	char **scid_str,
+	const tal_t *tal_ctx)
 {
 	const char *start = line;
 	const char *end = line + len;
-	while (start < end && (*start == ' ' || *start == '\t' || *start == '\r'))
-		start++;
-	while (end > start && (end[-1] == ' ' || end[-1] == '\t' || end[-1] == '\r'))
-		end--;
-	if (start == end) {
-		*text_out = tal_strdup(tal_ctx, "");
-		return true; /* Empty line allowed */
-	}
+
+	/* Trim whitespace */
+	while (start < end && isspace((unsigned char)*start))
+	start++;
+	while (end > start && isspace((unsigned char)end[-1]))
+	end--;
+
+	/* Empty line */
+	if (start == end)
+		return false;
+
+	/* Find the 'x' separators */
 	const char *x1 = memchr(start, 'x', (size_t)(end - start));
 	if (!x1)
 		return false;
 	const char *x2 = memchr(x1 + 1, 'x', (size_t)(end - (x1 + 1)));
 	if (!x2)
 		return false;
+
+	/* Parse the three numbers */
 	char *tmp;
-	unsigned long hh, tt, oo;
 	errno = 0;
-	hh = strtoul(start, &tmp, 10);
+	unsigned long hh = strtoul(start, &tmp, 10);
 	if (errno != 0 || tmp != x1)
 		return false;
+
 	errno = 0;
-	tt = strtoul(x1 + 1, &tmp, 10);
+	unsigned long tt = strtoul(x1 + 1, &tmp, 10);
 	if (errno != 0 || tmp != x2)
 		return false;
+
 	errno = 0;
-	oo = strtoul(x2 + 1, &tmp, 10);
+	unsigned long oo = strtoul(x2 + 1, &tmp, 10);
 	if (errno != 0 || tmp != end)
 		return false;
-	*h = hh; *t = tt; *o = oo;
-	*text_out = tal_strndup(tal_ctx, start, (size_t)(end - start));
+
+	*h = hh;
+	*t = tt;
+	*o = oo;
+
+	/* Store the original SCID string */
+	*scid_str = tal_strndup(tal_ctx, start, (size_t)(end - start));
+
 	return true;
 }
 
-static bool read_next_scid_fp(FILE *fp, const tal_t *tal_ctx,
-                              unsigned long *h,
-                              unsigned long *t,
-                              unsigned long *o,
-                              char **text_out)
+static bool read_next_scid(FILE *fp,
+	unsigned long *h,
+	unsigned long *t,
+	unsigned long *o,
+	char **scid_str,
+	const tal_t *tal_ctx)
 {
 	char *line = NULL;
 	size_t n = 0;
 	ssize_t r;
+
 	while ((r = getline(&line, &n, fp)) != -1) {
+		/* Validate first */
 		if (!validate_scid_line(line, (size_t)r))
 			continue;
-		if (parse_scid_triplet(line, (size_t)r, h, t, o, text_out, tal_ctx)) {
+
+		/* Try to parse */
+		if (parse_scid_triplet(line, (size_t)r, h, t, o, scid_str, tal_ctx)) {
 			free(line);
-			return (*text_out && **text_out);
+			return true;
 		}
 	}
+
 	free(line);
 	return false;
 }
@@ -1064,7 +1089,7 @@ int main(int argc, char *argv[])
         scid_fp = fopen(scid_file, "r");
         if (!scid_fp)
             err(1, "Could not open %s", scid_file);
-        have_scid = read_next_scid_fp(scid_fp, tal_ctx, &cur_h, &cur_t, &cur_o, &cur_scid_text);
+		have_scid = read_next_scid(scid_fp, &cur_h, &cur_t, &cur_o, &cur_scid_text, tal_ctx);
     }
 
 	if (use_testnet) {
@@ -1359,26 +1384,67 @@ check_genesis:
 			}
 
 			/* SCID matching: streaming from sorted file */
-			while (have_scid && (long)cur_h < b->height) {
-				/* cannot match in past blocks; advance to next scid */
-				have_scid = read_next_scid_fp(scid_fp, tal_ctx, &cur_h, &cur_t, &cur_o, &cur_scid_text);
-			}
-			if (have_scid && (unsigned long)b->height == cur_h) {
-				/* Consume all SCIDs for this block and current/next txs */
-				while (have_scid && (unsigned long)b->height == cur_h && (unsigned long)i == cur_t) {
-					unsigned long target_out = cur_o;
-					u64 amt = 0;
-					if (target_out < tx[i].output_count)
-						amt = tx[i].output[target_out].amount;
-					if (scid_outf && cur_scid_text && *cur_scid_text) {
-						fprintf(scid_outf, "%s:%u:%" PRIu64 "\n", cur_scid_text, b->bh.timestamp, amt);
-						if (!quiet && scid_outf != stdout)
-							fprintf(stdout, "%s:%u:%" PRIu64 "\n", cur_scid_text, b->bh.timestamp, amt);
+			if (have_scid) {
+				/* Skip blocks before current SCID */
+				if ((unsigned long)b->height < cur_h)
+					goto process_utxo;
+				
+				/* Process all SCIDs for current block */
+				if ((unsigned long)b->height == cur_h) {
+					/* Process all transactions up to current SCID */
+					if (i < cur_t)
+						goto process_utxo;
+					
+					/* We're at the right transaction, process matching SCIDs */
+					if (i == cur_t) {
+						while (have_scid && 
+							   (unsigned long)b->height == cur_h && 
+							   i == cur_t) {
+							
+							u64 amt = 0;
+							if (cur_o < tx[i].output_count)
+								amt = tx[i].output[cur_o].amount;
+							
+							/* Write output in format: <scid>:timestamp:amount */
+							if (scid_outf && cur_scid_text && *cur_scid_text) {
+								fprintf(scid_outf, "%s:%u:%" PRIu64 "\n",
+									cur_scid_text, 
+									b->bh.timestamp, amt);
+								
+								if (!quiet && scid_outf != stdout) {
+									fprintf(stdout, "%s:%u:%" PRIu64 "\n",
+										cur_scid_text,
+										b->bh.timestamp, amt);
+								}
+							}
+							
+							/* Free previous SCID text before reading next */
+							tal_free(cur_scid_text);
+							cur_scid_text = NULL;
+							
+							/* Read next SCID */
+							have_scid = read_next_scid(scid_fp, &cur_h, &cur_t, &cur_o, 
+										   &cur_scid_text, tal_ctx);
+						}
 					}
-					have_scid = read_next_scid_fp(scid_fp, tal_ctx, &cur_h, &cur_t, &cur_o, &cur_scid_text);
+				}
+				
+				/* If we've passed the current SCID block, advance to next valid SCID */
+				if ((unsigned long)b->height > cur_h) {
+					while (have_scid && (unsigned long)b->height > cur_h) {
+						if (!quiet)
+							warnx("SCID %s not found (block too high)",
+								  cur_scid_text ? cur_scid_text : "unknown");
+						
+						tal_free(cur_scid_text);
+						cur_scid_text = NULL;
+						have_scid = read_next_scid(scid_fp, &cur_h, &cur_t, &cur_o,
+									   &cur_scid_text, tal_ctx);
+					}
 				}
 			}
 
+			process_utxo:
 			if (needs_fee) {
 				/* Now we can release consumed utxos;
 				 * before there was a possibility of %tF */
@@ -1404,9 +1470,10 @@ check_genesis:
 		}
 	}
 
-	if (scid_outf && scid_outf != stdout)
-		fclose(scid_outf);
+	if (cur_scid_text)
+    	tal_free(cur_scid_text);
+	if (scid_fp)
+    	fclose(scid_fp);
 
-	/* No post-loop SCID write: we stream results during iteration */
 	return 0;
 }


### PR DESCRIPTION
## Overview

When analyzing Lightning Network gossip data as defined in [BOLT #7 — P2P Node and Channel Discovery](https://github.com/lightning/bolts/blob/master/07-routing-gossip.md#bolt-7-p2p-node-and-channel-discovery)
, each `channel_announcement` message requires a lookup in the Bitcoin blockchain to retrieve the corresponding channel capacity (`amount_sat`).
Notably, `channel_announcement` messages **do not include a timestamp**, making this lookup essential for accurate historical and analytical processing.

## What This PR Adds

This Pull Request introduces a new feature to bitcoin-iterate that allows efficient lookup of channel capacities directly from the blockchain using a list of Short Channel IDs (scids).

New Command-Line Options
```
--scid-file <path>
```

Specifies an input file containing a sorted list of scids.
Each scid must be ordered lexicographically by:
```
<block-height>, <transaction-index>, <output-index>
```

This sorting is required for optimized streaming reads and minimal memory usage.
```
--scid-out <path>
```

Specifies an output file where the matched scids and their corresponding capacities are written.
The results are stored in the following format:
```
<scid>:<timestamp>:<amount_sat>
```

## How It Works

The iterator sequentially scans the blockchain starting from the specified --start block (if provided).

For each scid in the input file, it searches for the corresponding output in the blockchain.

Upon finding a match, the script:

Writes the scid result (`scid:timestamp:amount_sat`) to the output file.

Prints the same information to stdout for real-time feedback.

The implementation is stream-based, requiring only one scid to be held in memory at a time — ensuring scalability for large input files.


## Example Usage

Given this `scids.txt` file
```
503816x1343x1
```

The following script:
./bitcoin-iterate \
  --start 503800 \
  --end 503900 \
  --scid-file scids.txt \
  --scid-out scid_results.txt \

Puts this into the `scid_results.txt` file
```

```

## Benefits

- Enables efficient channel capacity lookup for Lightning Network analysis.
- Handles large scid lists with minimal memory footprint.
- Provides structured, timestamped output for downstream data pipelines.
- Integrates seamlessly with existing blockchain iteration logic.